### PR TITLE
Amend Core Version Contraint

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -13,5 +13,5 @@ terraform {
       version = "~> 3.54.0, < 4.0.0"
     }
   }
-  required_version = "~> 0.12.0, < 0.15.0"
+  required_version = "> 0.12.0, < 0.15.0"
 }


### PR DESCRIPTION
Addressing the below.  Not quite sure what the cause is but this works. :man_shrugging

```
Initializing modules...

Error: Unsupported Terraform Core version

  on .terraform/modules/upload_to_jbc_s3_bucket/versions.tf line 16, in terraform:
  16:   required_version = "0.12.0, < 0.15.0"
```